### PR TITLE
Update observations.py

### DIFF
--- a/ssm/observations.py
+++ b/ssm/observations.py
@@ -797,7 +797,7 @@ class InputDrivenObservations(Observations):
                 hess += temp_hess - Xdf.T@pXdf
             # add contribution of prior to hessian
             if self.prior_sigma != 0:
-                hess += (1 / (self.prior_sigma) ** 2)
+                hess += (1 / (self.prior_sigma) ** 2) * np.eye((self.C - 1) * self.M)
             return hess/T
 
         from scipy.optimize import minimize


### PR DESCRIPTION
fixed prior Hessian for categorical input-driven class (line 800)
I believe the rhs of line 800 needs to be multiplied by an identity matrix (np.eye((self.C - 1) * self.M)). 
Currently it's adding a constant matrix.